### PR TITLE
Fixed missing property

### DIFF
--- a/exercises/5.html
+++ b/exercises/5.html
@@ -52,9 +52,7 @@
     </div>
     <script>
       var main = document.querySelector(".main");
-      var currentlyLightTheme = window.matchMedia(
-        "(prefers-color-scheme: light)"
-      );
+      var currentlyLightTheme = window.matchMedia("(prefers-color-scheme: light)").matches
       function toggle() {
         if (currentlyLightTheme) {
           main.className = "overrideLight";


### PR DESCRIPTION
matchMedia returns an array so the result is always truthy and the conditions won't work. Using the `.matches` property will validate the preference.