### PR TITLE
feat: update Orca shortcut

### DIFF
--- a/screen-reader-setup.html
+++ b/screen-reader-setup.html
@@ -83,7 +83,7 @@
               <code>sudo apt-get install orca</code> (Ubuntu/Debian)
             </li>
             <li>
-              Launch Orca: <kbd>Super</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
+              Launch Orca: <kbd>Super</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd>
             </li>
           </ol>
           <h3>Essential Commands</h3>


### PR DESCRIPTION
During the course I notice that the Orca shortcut in screen-reader-setup.html not working, this PR aims to update the Orca shortcut, following the documentation: https://help.ubuntu.com/stable/ubuntu-help/a11y-screen-reader.html.en